### PR TITLE
:active_model on_load hook will never run

### DIFF
--- a/lib/active_model/serializers.rb
+++ b/lib/active_model/serializers.rb
@@ -4,10 +4,6 @@ require 'active_record'
 require 'active_model'
 require "active_model/serializers/version"
 
-ActiveSupport.on_load(:active_model) do
-  require "active_model/serializers/xml"
-end
-
 ActiveSupport.on_load(:active_record) do
   require "active_record/serializers/xml_serializer"
 end


### PR DESCRIPTION
Active Model has no `on_load` hook. So this block just adds a useless hook that will never be executed.

I suppose the majority of the users are not aware of this because they're using Active Record. Otherwise, they must be forced to explicitly require "active_model/serializers/xml" somewhere in their codebase.

Maybe we can add the `on_load` hook to AM/model.rb (this file was not included in the initial version of Active Model, but now we have something equivalent to `base.rb`) for future improvement?