### PR TITLE
active_model/serializers does not require active_record

### DIFF
--- a/activemodel-serializers-xml.gemspec
+++ b/activemodel-serializers-xml.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.add_dependency "activesupport", "> 5.x"
   spec.add_dependency "activemodel", "> 5.x"
-  spec.add_dependency "activerecord", "> 5.x"
   spec.add_dependency "builder", "~> 3.1"
 
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "activerecord", "> 5.x"
   spec.add_development_dependency "sqlite3"
 end

--- a/lib/active_model/serializers.rb
+++ b/lib/active_model/serializers.rb
@@ -1,6 +1,5 @@
 require 'active_support'
 require 'active_support/lazy_load_hooks'
-require 'active_record'
 require 'active_model'
 require "active_model/serializers/version"
 


### PR DESCRIPTION
The `require 'active_record'` in serializers.rb was added at 94990dac3dea62522da80ae104cf991f2d82f11a to resolve #3, but this was too much.
There are cases where we don't use Active Record and so we don't want to load AR::Base here.

Also removed the runtime dependency to AR for the same reason.
This won't cause any compatibility problem for existing AR users because AR support will be loaded via `ActiveSupport.on_load(:active_record)` hook when they required AR::Base.