### PR TITLE
Replace ActiveModel::TestCase with ActiveSupport::TestCase

### DIFF
--- a/test/active_model/xml_serialization_test.rb
+++ b/test/active_model/xml_serialization_test.rb
@@ -28,7 +28,7 @@ class SerializableContact < Contact
   end
 end
 
-class AMXmlSerializationTest < ActiveModel::TestCase
+class AMXmlSerializationTest < ActiveSupport::TestCase
   def setup
     @contact = Contact.new
     @contact.name = 'aaron stack'


### PR DESCRIPTION
ActiveModel::TestCase was removed in Rails 5.1 (rails/rails/pull/27928).