### PR TITLE
should not pass methods option to field's to_xml

### DIFF
--- a/lib/active_model/serializers/xml.rb
+++ b/lib/active_model/serializers/xml.rb
@@ -107,9 +107,10 @@ module ActiveModel
 
         def add_attributes_and_methods
           serializable_collection.each do |attribute|
-            key = ActiveSupport::XmlMini.rename_key(attribute.name, options)
+            _options = options.except(:methods)
+            key = ActiveSupport::XmlMini.rename_key(attribute.name, _options)
             ActiveSupport::XmlMini.to_tag(key, attribute.value,
-              options.merge(attribute.decorations))
+              _options.merge(attribute.decorations))
           end
         end
 

--- a/test/active_model/xml_serialization_test.rb
+++ b/test/active_model/xml_serialization_test.rb
@@ -28,6 +28,39 @@ class SerializableContact < Contact
   end
 end
 
+class Role
+  include ActiveModel::Serializers::Xml
+  attr_accessor :title
+
+  def initialize(title)
+    @title = title
+  end
+
+  def attributes
+    instance_values
+  end
+end
+
+class Human
+  include ActiveModel::Serializers::Xml
+
+  attr_accessor :first_name, :last_name, :role
+
+  def initialize(first_name, last_name, role)
+    @first_name = first_name
+    @last_name  = last_name
+    @role = role
+  end
+
+  def full_name
+    first_name + ' ' + last_name
+  end
+
+  def attributes
+    instance_values
+  end
+end
+
 class AMXmlSerializationTest < ActiveSupport::TestCase
   def setup
     @contact = Contact.new
@@ -247,5 +280,12 @@ class AMXmlSerializationTest < ActiveSupport::TestCase
   test "association with sti" do
     xml = @contact.to_xml(include: :contact)
     assert xml.include?(%(<contact type="SerializableContact">))
+  end
+
+  test "computed property applies only to root" do
+    role = Role.new("manager")
+    human = Human.new("Jane", "Air", role)
+    xml = human.to_xml(methods: :full_name)
+    assert_match %r{<full-name>}, xml
   end
 end


### PR DESCRIPTION
During the upgrade to the Rails 5, I found that to_xml with the option :methods works incorrectly, it tries apply this method not only for root, also for nested entities.

Earlier it worked because ActiveModel verified method existence and nonexistent methods on nested entities were not called, but that commit changes behaviour: https://github.com/rails/rails/commit/b2967999aeb424d219393f2e01e88a92f37a78c3

So, now it falls with error.

