### PR TITLE
`timestamps` creates `created_at` field.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -106,7 +106,6 @@ ActiveRecord::Schema.define do
     t.string :name
     t.integer :age
     t.binary :avatar
-    t.datetime :created_at
     t.boolean :awesome
     t.string :preferences
     t.integer :alternative_id
@@ -119,7 +118,6 @@ ActiveRecord::Schema.define do
     t.string :name
     t.integer :age
     t.binary :avatar
-    t.datetime :created_at
     t.boolean :awesome
     t.string :preferences
     t.integer :alternative_id


### PR DESCRIPTION
The `t.timestamps`, available since Rails 2.3, already creates the `created_at` column. Therefore, since Rails 6.0+ the test suite fails with the following error:

~~~
/usr/share/gems/gems/activerecord-6.0.3.2/lib/active_record/connection_adapters/abstract/schema_definitions.rb:372:in `column': you can't define an already defined column 'created_at'. (ArgumentError)
	from /usr/share/gems/gems/activerecord-6.0.3.2/lib/active_record/connection_adapters/abstract/schema_definitions.rb:411:in `timestamps'
	from /builddir/build/BUILD/test/helper.rb:114:in `block (2 levels) in <top (required)>'
~~~