### PR TITLE
Add REXML development dependency

### DIFF
--- a/activemodel-serializers-xml.gemspec
+++ b/activemodel-serializers-xml.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "activerecord", ">= 5.0.0.a"
   spec.add_development_dependency "sqlite3", "~> 1.3.6"
+  spec.add_development_dependency "rexml"
 end


### PR DESCRIPTION
This is required to make the test suite pass on Ruby 3.0, where the REXML was moved out of StdLib to bundled gems.